### PR TITLE
Make compatible with laravel/scout 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "tamayo/laravel-scout-elastic": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Engines/NestedElasticSearchEngine.php
+++ b/src/Engines/NestedElasticSearchEngine.php
@@ -3,7 +3,8 @@
 namespace CF\Scout\Engines;
 
 use Laravel\Scout\Builder;
-use Laravel\Scout\Engines\ElasticsearchEngine;
+use ScoutEngines\Elasticsearch\ElasticsearchEngine;
+
 
 class NestedElasticSearchEngine extends ElasticsearchEngine
 {
@@ -210,7 +211,7 @@ class NestedElasticSearchEngine extends ElasticsearchEngine
             ]);
         }
 
-        return $this->elasticsearch->search($searchQuery);
+        return $this->elastic->search($searchQuery);
     }
 
 }


### PR DESCRIPTION
The ElasticSearch engine has been removed from Scout 2.0 and greater so we need to pull in another package and extend from that instead.

See https://github.com/laravel/scout/releases/tag/v2.0.0