### PR TITLE
Remove composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "tamayo/laravel-scout-elastic": "^8.0"
+        "php": ">=7.3.2",
+        "tamayo/laravel-scout-elastic": "^8.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I noticed the other composer packages do not include the composer.lock file.  Hoping this will resolve the error being provided
```
In NestedElasticSearchEngine.php line 8:
Class 'ScoutEngines\Elasticsearch\ElasticsearchEngine' not found 
```